### PR TITLE
Make EC parts of XCA depend on OpenSSL config

### DIFF
--- a/configure
+++ b/configure
@@ -140,14 +140,12 @@ export LD_LIBRARY_PATH
 cat >conftest.c <<EOF
 #include <stdio.h>
 #include <openssl/opensslv.h>
-//#include <opensc/opensc.h>
+#include <openssl/opensslconf.h>
 #include <Qt/qglobal.h>
 
 int main(){
   printf("\nThe Versions of the used libraries are:\n\t%s 0x%lxL\n\tQT: %s\n",
-//	 "\tOpenSC: %s\n",
 	 OPENSSL_VERSION_TEXT, OPENSSL_VERSION_NUMBER, QT_VERSION_STR
-//	, sc_get_version()
 	);
 
   if (QT_VERSION < 0x040300) {
@@ -158,6 +156,10 @@ int main(){
 	printf("You need OpenSSL >= 0.9.8 or higher\n");
 	return 1;
   }
+#ifdef OPENSSL_NO_EC
+  printf("\n###  This OpenSSL installation has no EC cryptography support\n");
+#endif
+  puts("\n");
   return 0;
 }
 EOF

--- a/lib/pki_evp.cpp
+++ b/lib/pki_evp.cpp
@@ -27,10 +27,11 @@ QString pki_evp::passHash = QString();
 
 QPixmap *pki_evp::icon[2]= { NULL, NULL };
 
+#ifndef OPENSSL_NO_EC
 EC_builtin_curve *pki_evp::curves = NULL;
 size_t pki_evp::num_curves = 0;
 unsigned char *pki_evp::curve_flags = NULL;
-
+#endif
 void pki_evp::erasePasswd()
 {
 	memset(passwd, 0, MAX_PASS_LENGTH);
@@ -101,8 +102,9 @@ void pki_evp::generate(int bits, int type, QProgressBar *progress, int curve_nid
 {
 	RSA *rsakey;
 	DSA *dsakey;
+#ifndef OPENSSL_NO_EC
 	EC_KEY *eckey;
-
+#endif
 	progress->setMinimum(0);
 	progress->setMaximum(100);
 	progress->setValue(50);
@@ -122,6 +124,7 @@ void pki_evp::generate(int bits, int type, QProgressBar *progress, int curve_nid
 		if (dsakey)
 			EVP_PKEY_assign_DSA(key, dsakey);
 		break;
+#ifndef OPENSSL_NO_EC
 	case EVP_PKEY_EC:
 		EC_GROUP *group = EC_GROUP_new_by_curve_name(curve_nid);
 		if (!group)
@@ -142,6 +145,7 @@ void pki_evp::generate(int bits, int type, QProgressBar *progress, int curve_nid
 		EC_KEY_free(eckey);
 		EC_GROUP_free(group);
 		break;
+#endif
 	}
 	pki_openssl_error();
 	encryptKey();
@@ -180,8 +184,10 @@ static bool EVP_PKEY_isPrivKey(EVP_PKEY *key)
 			return key->pkey.rsa->d ? true: false;
 		case EVP_PKEY_DSA:
 			return key->pkey.dsa->priv_key ? true: false;
+#ifndef OPENSSL_NO_EC
 		case EVP_PKEY_EC:
 			return EC_KEY_get0_private_key(key->pkey.ec) ? true: false;
+#endif
 	}
 	return false;
 }
@@ -225,7 +231,7 @@ void pki_evp::fromPEM_BIO(BIO *bio, QString name)
 	}
 	openssl_error(name);
 }
-
+#ifndef OPENSSL_NO_EC
 static void search_ec_oid(EC_KEY *ec)
 {
 	const EC_GROUP *ec_group = EC_KEY_get0_group(ec);
@@ -250,7 +256,7 @@ static void search_ec_oid(EC_KEY *ec)
 		}
 	}
 }
-
+#endif
 void pki_evp::fload(const QString fname)
 {
 	pass_info p(XCA_TITLE, qApp->translate("MainWindow",
@@ -311,8 +317,10 @@ void pki_evp::fload(const QString fname)
 		throw errorEx(tr("Unable to load the private key in file %1. Tried PEM and DER private, public and PKCS#8 key types.").arg(fname));
 	}
 	if (pkey){
+#ifndef OPENSSL_NO_EC
 		if (pkey->type == EVP_PKEY_EC)
 			search_ec_oid(pkey->pkey.ec);
+#endif
 		if (key)
 			EVP_PKEY_free(key);
 		key = pkey;
@@ -659,7 +667,9 @@ const EVP_MD *pki_evp::getDefaultMD()
 	switch (key->type) {
 		case EVP_PKEY_RSA: md = EVP_sha1(); break;
 		case EVP_PKEY_DSA: md = EVP_dss1(); break;
+#ifndef OPENSSL_NO_EC
 		case EVP_PKEY_EC:  md = EVP_ecdsa(); break;
+#endif
 		default: md = NULL; break;
 	}
 	return md;

--- a/lib/pki_evp.h
+++ b/lib/pki_evp.h
@@ -37,10 +37,11 @@ class pki_evp: public pki_key
 		static void setOldPasswd(const char *pass);
 		static QString md5passwd(const char *pass);
 		static QString sha512passwd(QString pass, QString salt);
+#ifndef OPENSSL_NO_EC
 		static EC_builtin_curve *curves;
 		static size_t num_curves;
 		static unsigned char *curve_flags;
-
+#endif
 		void generate(int bits, int type, QProgressBar *progress);
 		void generate(int bits, int type, QProgressBar *progress,
 				int curve_nid);

--- a/lib/pki_key.cpp
+++ b/lib/pki_key.cpp
@@ -209,7 +209,7 @@ QString pki_key::pubkey()
 		return BN2QString(key->pkey.dsa->pub_key);
 	return QString();
 }
-
+#ifndef OPENSSL_NO_EC
 int pki_key::ecParamNid()
 {
 	if (key->type != EVP_PKEY_EC)
@@ -232,7 +232,7 @@ QString pki_key::ecPubKey()
 	}
 	return pub;
 }
-
+#endif
 bool pki_key::compare(pki_base *ref)
 {
 	pki_key *kref = (pki_key *)ref;

--- a/lib/pki_scard.cpp
+++ b/lib/pki_scard.cpp
@@ -113,6 +113,7 @@ EVP_PKEY *pki_scard::load_pubkey(pkcs11 &p11, CK_OBJECT_HANDLE object) const
 		EVP_PKEY_assign_DSA(pkey, dsa);
 		break;
 	}
+#ifndef OPENSSL_NO_EC
 	case CKK_EC: {
 		EC_KEY *ec = EC_KEY_new();
 
@@ -137,6 +138,7 @@ EVP_PKEY *pki_scard::load_pubkey(pkcs11 &p11, CK_OBJECT_HANDLE object) const
 		EVP_PKEY_assign_EC_KEY(pkey, ec);
 		break;
 	}
+#endif
 	default:
 		throw errorEx(QString("Unsupported CKA_KEY_TYPE: %1\n").arg(keytype));
 	}
@@ -368,7 +370,9 @@ QList<int> pki_scard::possibleHashNids()
 		switch (mech_list[i]) {
 		case CKM_MD5_RSA_PKCS:    nids << NID_md5; break;
 		case CKM_DSA_SHA1:
+#ifndef OPENSSL_NO_EC
 		case CKM_ECDSA_SHA1:
+#endif
 		case CKM_SHA1_RSA_PKCS:   nids << NID_sha1; break;
 		case CKM_SHA256_RSA_PKCS: nids << NID_sha256; break;
 		case CKM_SHA384_RSA_PKCS: nids << NID_sha384; break;
@@ -389,8 +393,10 @@ const EVP_MD *pki_scard::getDefaultMD()
 		return EVP_sha1();
 	if (mech_list.contains(CKM_DSA_SHA1))
 		return EVP_dss1();
+#ifndef OPENSSL_NO_EC
 	if (mech_list.contains(CKM_ECDSA_SHA1))
 		return EVP_ecdsa();
+#endif
 	if (mech_list.contains(CKM_SHA512_RSA_PKCS))
 		return EVP_sha512();
 	if (mech_list.contains(CKM_SHA384_RSA_PKCS))

--- a/widgets/KeyDetail.cpp
+++ b/widgets/KeyDetail.cpp
@@ -24,7 +24,7 @@ KeyDetail::KeyDetail(QWidget *parent)
 	image->setPixmap(*MainWindow::keyImg);
 	keyDesc->setReadOnly(true);
 }
-
+#ifndef OPENSSL_NO_EC
 static QString CurveComment(int nid)
 {
 	for (size_t i=0; i<pki_evp::num_curves; i++) {
@@ -33,7 +33,7 @@ static QString CurveComment(int nid)
 	}
 	return QString();
 }
-
+#endif
 void KeyDetail::setKey(pki_key *key)
 {
 	int nid;
@@ -74,6 +74,7 @@ void KeyDetail::setKey(pki_key *key)
 			keyPubEx->setText(key->subprime());
 			keyModulus->setText(key->pubkey());
 			break;
+#ifndef OPENSSL_NO_EC
 		case EVP_PKEY_EC:
 			nid = key->ecParamNid();
 			tlModulus->setText(tr("Public key"));
@@ -83,6 +84,7 @@ void KeyDetail::setKey(pki_key *key)
 			keyPubEx->setToolTip(CurveComment(nid));
 			keyModulus->setText(key->ecPubKey());
 			break;
+#endif
 		default:
 			tlHeader->setText(tr("Unknown key"));
 	}

--- a/widgets/MainWindow.cpp
+++ b/widgets/MainWindow.cpp
@@ -98,7 +98,7 @@ static const int other_curve_nids[] = {
 	NID_secp384r1,
 	NID_secp521r1
 };
-
+#ifndef OPENSSL_NO_EC
 static void init_curves()
 {
 	pki_evp::num_curves = EC_get_builtin_curves(NULL, 0);
@@ -130,7 +130,7 @@ static void init_curves()
 		}
 	}
 }
-
+#endif
 void MainWindow::enableTokenMenu(bool enable)
 {
 	foreach(QAction* a, scardMenuActions)
@@ -184,9 +184,9 @@ MainWindow::MainWindow(QWidget *parent )
 
 	init_images();
 	homedir = getHomeDir();
-
+#ifndef OPENSSL_NO_EC
 	init_curves();
-
+#endif
 #ifdef MDEBUG
 	CRYPTO_malloc_debug_init();
 	CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON);

--- a/widgets/NewKey.cpp
+++ b/widgets/NewKey.cpp
@@ -24,7 +24,9 @@ struct typelist {
 static const struct typelist typeList[] = {
 	{ "RSA", EVP_PKEY_RSA },
 	{ "DSA", EVP_PKEY_DSA },
+#ifndef OPENSSL_NO_EC
 	{ "EC",  EVP_PKEY_EC  },
+#endif
 };
 
 class keyListItem
@@ -97,7 +99,7 @@ NewKey::NewKey(QWidget *parent, QString name)
 		keyListItem gk(typeList +i);
 		keytypes << gk;
 	}
-
+#ifndef OPENSSL_NO_EC
 	for (i = 0; i<pki_evp::num_curves; i++) {
 		const char *desc = pki_evp::curves[i].comment;
 		const char *sn = OBJ_nid2sn(pki_evp::curves[i].nid);
@@ -115,6 +117,7 @@ NewKey::NewKey(QWidget *parent, QString name)
 	}
 	curveBox->addItems(curve_x962);
 	curveBox->addItems(curve_other);
+#endif
 	keyLength->setCurrentIndex(0);
 	keyDesc->setFocus();
 	if (pkcs11::loaded()) try {

--- a/widgets/hashBox.cpp
+++ b/widgets/hashBox.cpp
@@ -40,8 +40,10 @@ const EVP_MD *hashBox::currentHash()
 	switch(key_type) {
 	case EVP_PKEY_DSA:
 		return EVP_dss1();
+#ifndef OPENSSL_NO_EC
 	case EVP_PKEY_EC:
 		return EVP_ecdsa();
+#endif
 	default:
 		QString hash = currentText();
 		for (unsigned i=0; i<ARRAY_SIZE(hashalgos); i++) {


### PR DESCRIPTION
Some distributions ship an OpenSSL installation without
EC Support.
XCA evaluates the OPENSSL_NO_EC flag to disable EC

Thanks to Andreas Piesk for his patch